### PR TITLE
add live volume support (using volume filter if available)

### DIFF
--- a/ffpyplayer/ff_defs.pxi
+++ b/ffpyplayer/ff_defs.pxi
@@ -483,6 +483,9 @@ cdef:
         AVFilter *avfilter_get_by_name(const char *)
         void avfilter_graph_free(AVFilterGraph **)
         AVFilterGraph *avfilter_graph_alloc()
+        int avfilter_graph_send_command(AVFilterGraph *, const char *,
+                                        const char *, const char *, char *,
+                                        int, int)
 
     extern from "libavfilter/buffersink.h" nogil:
         int av_buffersink_get_frame_flags(AVFilterContext *, AVFrame *, int)

--- a/ffpyplayer/ffcore.pxd
+++ b/ffpyplayer/ffcore.pxd
@@ -106,6 +106,7 @@ cdef class VideoState(object):
             AVFilterContext *in_audio_filter   # the first filter in the audio chain
             AVFilterContext *out_audio_filter  # the last filter in the audio chain
             AVFilterContext *split_audio_filter  # the last filter in the audio chain
+            AVFilterContext *audio_volume_filter
             AVFilterGraph *agraph              # audio filter graph
 
         int last_video_stream, last_audio_stream, last_subtitle_stream
@@ -147,7 +148,7 @@ cdef class VideoState(object):
     cdef int get_video_frame(VideoState self, AVFrame *frame, AVPacket *pkt, int *serial) nogil except 2
     IF CONFIG_AVFILTER:
         cdef int configure_filtergraph(VideoState self, AVFilterGraph *graph, const char *filtergraph,
-                                       AVFilterContext *source_ctx, AVFilterContext *sink_ctx) nogil except? 1
+                                       AVFilterContext *source_ctx, AVFilterContext *sink_ctx, int final) nogil except? 1
         cdef int configure_video_filters(VideoState self, AVFilterGraph *graph,
                                          const char *vfilters, AVFrame *frame,
                                          AVPixelFormat pix_fmt) nogil except? 1
@@ -167,3 +168,4 @@ cdef class VideoState(object):
     cdef inline int failed(VideoState self, int ret) nogil except 1
     cdef int stream_cycle_channel(VideoState self, int codec_type, int requested_stream) nogil except 1
     cdef int decode_interrupt_cb(VideoState self) nogil
+    cdef int set_volume(VideoState self, float volume) nogil

--- a/ffpyplayer/player.pyx
+++ b/ffpyplayer/player.pyx
@@ -576,6 +576,7 @@ cdef class MediaPlayer(object):
             *volume* (float): A value between 0.0 - 1.0.
         '''
         self.settings.volume = min(max(volume, 0.), 1.) * SDL_MIX_MAXVOLUME
+        self.ivs.set_volume(volume)
 
     def get_volume(self):
         '''


### PR DESCRIPTION
Currently, the Kivy core provider is unable to set any volume. This is due to the fact that:
- MediaPlayer.set_volume() have an impact only on settings
- I didn't find a reference to the volume anywhere
- Even if it was in the settings, settings are not reloaded after the video start playing, and there is no way to set it after creating the MediaPlayer.

This PR add a volume filter that is controlled via set_volume as well. This allow live-changes of the volume. It does have no impact if no volume filter is available (it was the case on previous python-for-android build, and i guess kivy-ios too.)

The only bug i didn't find out is that the volume is set back to 1. after a seek. Otherwise, check your own demo, it works like a charm :)

NB: it also include an option to not finalize the graph until we link our last 2 components. Currently used only for audio, but it might be others futures case for that as well.
