### PR TITLE
Add aspect ratio to the list of items return by get_metadata().

### DIFF
--- a/ffpyplayer/player/player.pyx
+++ b/ffpyplayer/player/player.pyx
@@ -622,8 +622,9 @@ cdef class MediaPlayer(object):
                 numerator and denominator. src and sink video sizes correspond to
                 the frame size of the original video, and the frames returned by
                 :meth:`get_frame`, respectively. `src_pix_fmt` is the pixel format
-                of the original input stream. Duration is the file duration and
-                defaults to None until updated.
+                of the original input stream. 'aspect_ratio' is the source to 
+                display aspect ratio as a numerator and denominator. Duration 
+                is the file duration and defaults to None until updated.
 
         :
 


### PR DESCRIPTION
This will allow broadcast video that is decoded at 4:3 resolution but should be displayed at 16:9 resolution to be rendered correctly when displayed