### PR TITLE
Add is_key_frame to Image class to allow detection of key frames

### DIFF
--- a/ffpyplayer/includes/ffmpeg.pxi
+++ b/ffpyplayer/includes/ffmpeg.pxi
@@ -427,6 +427,7 @@ cdef:
             AVRational sample_aspect_ratio
             int width, height
             int format
+            int key_frame
             int64_t pts
             int64_t pkt_pts
             int64_t pkt_dts

--- a/ffpyplayer/pic.pxd
+++ b/ffpyplayer/pic.pxd
@@ -20,6 +20,7 @@ cdef class Image(object):
 
     cdef int cython_init(self, AVFrame *frame) nogil except 1
     cpdef is_ref(Image self)
+    cpdef is_key_frame(Image self)
     cpdef get_linesizes(Image self, keep_align=*)
     cpdef get_size(Image self)
     cpdef get_pixel_format(Image self)

--- a/ffpyplayer/pic.pyx
+++ b/ffpyplayer/pic.pyx
@@ -505,6 +505,15 @@ cdef class Image(object):
         '''
         return self.frame.buf[0] != NULL
 
+    cpdef is_key_frame(Image self):
+        '''Returns whether the image is a key frame.
+
+        :returns:
+
+            bool: True if the image was a key frame.
+        '''
+        return self.frame.key_frame == 1
+
     cpdef get_linesizes(Image self, keep_align=False):
         '''Returns the linesize of each plane.
 


### PR DESCRIPTION
This is useful to prevent showing partial frames to the user by waiting for the first key frame to be decoded before displaying/using frame data.