### PR TITLE
Fix dll issues on win

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -107,10 +107,7 @@ jobs:
         $name = python -c "import ffpyplayer, os.path;print(os.path.dirname(ffpyplayer.__file__))"
         echo $name
         try {pytest -Wignore "$name\tests"}
-        catch {echo "hit error"}
-
-        echo "error is"
-        echo $Error
+        catch {echo "hit error $_.ScriptStackTrace... $_.Exception... $_.ErrorDetails"}
 
   linux_test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -106,12 +106,11 @@ jobs:
         python -m pip install --no-index --find-links=$dist_path ffpyplayer
         $name = python -c "import ffpyplayer, os.path;print(os.path.dirname(ffpyplayer.__file__))"
         echo $name
-        $res=(pytest -Wignore "$name\tests" 2>&1)
+        try {pytest -Wignore "$name\tests"}
+        catch {echo "hit error"}
 
         echo "error is"
         echo $Error
-        echo "result is"
-        echo $res
 
   linux_test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -106,7 +106,12 @@ jobs:
         python -m pip install --no-index --find-links=$dist_path ffpyplayer
         $name = python -c "import ffpyplayer, os.path;print(os.path.dirname(ffpyplayer.__file__))"
         echo $name
-        pytest -Wignore "$name\tests"
+        $res=(pytest -Wignore "$name\tests")
+
+        echo "error is"
+        echo $Error
+        echo "result is"
+        echo $res
 
   linux_test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -106,8 +106,16 @@ jobs:
         python -m pip install --no-index --find-links=$dist_path ffpyplayer
         $name = python -c "import ffpyplayer, os.path;print(os.path.dirname(ffpyplayer.__file__))"
         echo $name
-        try {pytest "$name\tests"}
-        catch {echo "$?; $LastExitCode"}
+        # powershell interprets writing to stderr as an error, so only raise error if the return code is none-zero
+        try {
+          pytest "$name\tests"
+        } catch {
+          if ($LastExitCode -ne 0) {
+            throw $_
+          } else {
+            echo $_
+          }
+        }
 
   linux_test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -96,9 +96,6 @@ jobs:
         Invoke-WebRequest  "https://github.com/matham/ffpyplayer/releases/download/v4.1.0/ffmpeg_win_dll_container_deps.zip"  -OutFile "ffmpeg_win_dll_container_deps.zip"
         7z x "ffmpeg_win_dll_container_deps.zip"
         $env:PATH="$env:PATH;$env:GITHUB_WORKSPACE\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
-        echo $env:PATH
-        ls "$env:GITHUB_WORKSPACE\ffpyplayer"
-        ls "$env:GITHUB_WORKSPACE\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
 
         $dist_path=(get-item dist).FullName
         $root=(get-item .).FullName
@@ -108,7 +105,7 @@ jobs:
         python -m pip install --no-index --find-links=$dist_path ffpyplayer
         $name = python -c "import ffpyplayer, os.path;print(os.path.dirname(ffpyplayer.__file__))"
         echo $name
-        pytest "$name\tests"
+        pytest -Wignore "$name\tests"
 
   linux_test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -106,8 +106,8 @@ jobs:
         python -m pip install --no-index --find-links=$dist_path ffpyplayer
         $name = python -c "import ffpyplayer, os.path;print(os.path.dirname(ffpyplayer.__file__))"
         echo $name
-        try {pytest -Wignore "$name\tests"}
-        catch {echo "hit error $_.ScriptStackTrace... $_.Exception... $_.ErrorDetails"}
+        try {pytest "$name\tests"}
+        catch {echo "$?; $LastExitCode"}
 
   linux_test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -96,6 +96,7 @@ jobs:
         Invoke-WebRequest  "https://github.com/matham/ffpyplayer/releases/download/v4.1.0/ffmpeg_win_dll_container_deps.zip"  -OutFile "ffmpeg_win_dll_container_deps.zip"
         7z x "ffmpeg_win_dll_container_deps.zip"
         $env:PATH="$env:PATH;$env:GITHUB_WORKSPACE\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
+        ls "$env:GITHUB_WORKSPACE\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
 
         $dist_path=(get-item dist).FullName
         $root=(get-item .).FullName

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -106,7 +106,7 @@ jobs:
         python -m pip install --no-index --find-links=$dist_path ffpyplayer
         $name = python -c "import ffpyplayer, os.path;print(os.path.dirname(ffpyplayer.__file__))"
         echo $name
-        $res=(pytest -Wignore "$name\tests")
+        $res=(pytest -Wignore "$name\tests" 2>&1)
 
         echo "error is"
         echo $Error

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -89,12 +89,16 @@ jobs:
         path: dist
     - name: Test
       run: |
+        # see https://social.msdn.microsoft.com/Forums/security/en-US/0c13bd1a-388f-48cf-a190-7259d39a080f/ffmpeg-doesnt-work-from-inside-a-container-but-works-on-the-host?forum=windowscontainers
+        # https://trac.ffmpeg.org/ticket/6875, https://stackoverflow.com/questions/46147012/opencv-import-failed-in-windows-container-on-windows-server-2016
+        # and https://social.msdn.microsoft.com/Forums/en-US/a95032d2-c469-494a-b3f9-521b1389a6c9/cant-use-opencvpython-package-in-windows-container-windows-server-2016-standard?forum=windowscontainers
+        # for the reason we need to manually copy some missing dlls to the PATH
         Invoke-WebRequest  "https://github.com/matham/ffpyplayer/releases/download/v4.1.0/ffmpeg_win_dll_container_deps.zip"  -OutFile "ffmpeg_win_dll_container_deps.zip"
         7z x "ffmpeg_win_dll_container_deps.zip"
-        $env:PATH="$env:PATH;$env:GITHUB_WORKSPACE\ffpyplayer\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
+        $env:PATH="$env:PATH;$env:GITHUB_WORKSPACE\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
         echo $env:PATH
         ls "$env:GITHUB_WORKSPACE\ffpyplayer"
-        ls "$env:GITHUB_WORKSPACE\ffpyplayer\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
+        ls "$env:GITHUB_WORKSPACE\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
 
         $dist_path=(get-item dist).FullName
         $root=(get-item .).FullName

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: [ '3.6', '3.7' ]
+        python: [ '3.6', '3.7', '3.8' ]
         arch: ['x64', 'x86']
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python: [ '3.6', '3.7', '3.8' ]
+        python: [ '3.6', '3.7' ]
         arch: ['x64', 'x86']
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -88,8 +88,14 @@ jobs:
         name: py_wheel
         path: dist
     - name: Test
-      if: matrix.arch == 'testing is failing due to missing dll on ci for some reason'
       run: |
+        Invoke-WebRequest  "https://github.com/matham/ffpyplayer/releases/download/v4.1.0/ffmpeg_win_dll_container_deps.zip"  -OutFile "ffmpeg_win_dll_container_deps.zip"
+        7z x "ffmpeg_win_dll_container_deps.zip"
+        $env:PATH="$env:PATH;$env:GITHUB_WORKSPACE\ffpyplayer\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
+        echo $env:PATH
+        ls "$env:GITHUB_WORKSPACE\ffpyplayer"
+        ls "$env:GITHUB_WORKSPACE\ffpyplayer\ffmpeg_win_dll_container_deps\${{ matrix.arch }}"
+
         $dist_path=(get-item dist).FullName
         $root=(get-item .).FullName
         $env:FFPYPLAYER_TEST_DIRS="$root\ffpyplayer\tests;$root\examples"

--- a/ffpyplayer/__init__.py
+++ b/ffpyplayer/__init__.py
@@ -33,12 +33,18 @@ It is read only.
 
 _ffmpeg = join(sys.prefix, 'share', 'ffpyplayer', 'ffmpeg', 'bin')
 if isdir(_ffmpeg):
-    os.environ["PATH"] += os.pathsep + _ffmpeg
+    if hasattr(os, 'add_dll_directory'):
+        os.add_dll_directory(_ffmpeg)
+    else:
+        os.environ["PATH"] += os.pathsep + _ffmpeg
     dep_bins.append(_ffmpeg)
 
 _sdl = join(sys.prefix, 'share', 'ffpyplayer', 'sdl', 'bin')
 if isdir(_sdl):
-    os.environ["PATH"] += os.pathsep + _sdl
+    if hasattr(os, 'add_dll_directory'):
+        os.add_dll_directory(_sdl)
+    else:
+        os.environ["PATH"] += os.pathsep + _sdl
     dep_bins.append(_sdl)
 
 if 'SDL_AUDIODRIVER' not in os.environ and platform.system() == 'Windows':


### PR DESCRIPTION
* Fixes [missing dlls](https://social.msdn.microsoft.com/Forums/en-US/a95032d2-c469-494a-b3f9-521b1389a6c9/cant-use-opencvpython-package-in-windows-container-windows-server-2016-standard?forum=windowscontainers) on the github action windows containers. So I uploaded these ffmpeg required dlls from my window installation so we can use them during the testing phase on CI. They are not distributed in the wheel.
* Also fixed issue wherepy3.8 doesn't load dlls from PATH anymore - they have to be added explicitly with `add_dll_directory`.