### PR TITLE
Upgrade GitHub Actions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -22,9 +22,9 @@ jobs:
       matrix:
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python }}
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python }}
     - name: Get dependencies
@@ -74,7 +74,7 @@ jobs:
         $env:FFMPEG_ROOT=(get-item $env:FFMPEG_ROOT).FullName
         python setup.py bdist_wheel
     - name: Upload wheel
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: py_wheel
         path: dist
@@ -127,12 +127,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: windows_wheels_tests
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: py_wheel
           path: dist
@@ -161,12 +161,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: linux_wheels
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: py_wheel
           path: dist
@@ -211,15 +211,15 @@ jobs:
 #          - cibw_archs: aarch64
 #            cibw_build: cp310-manylinux_aarch64
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Set up QEMU
         if: ${{ matrix.cibw_archs == 'aarch64' }}
         uses: docker/setup-qemu-action@v1
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: deps-cache
         with:
           path: ffmpeg_build
@@ -236,7 +236,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
       - name: Upload wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: py_wheel
           path: dist
@@ -271,15 +271,15 @@ jobs:
       matrix:
         arch: [ "x86_64", "arm64" ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
       - name: Cache ffmpeg
         id: cache-ffmpeg
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/${{ env.FFMPEG_BUILD_PATH }}_${{ matrix.arch }}
           key: ${{ runner.os }}-ffmpeg-${{ matrix.arch }}-${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ env.MACOSX_DEPLOYMENT_TARGET_ARM }}-${{ hashFiles('.ci/build_wheels_osx.sh') }}
@@ -297,7 +297,7 @@ jobs:
           python -m cibuildwheel --output-dir dist
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: py_wheel
           path: dist
@@ -306,13 +306,13 @@ jobs:
     runs-on: macos-latest
     needs: osx_wheels_create
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: py_wheel
           path: dist
@@ -324,7 +324,7 @@ jobs:
           bash ../.ci/merge_osx_deps.sh
 
       - name: Upload wheel
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: py_wheel
           path: dist
@@ -359,9 +359,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python 3.x
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.x
       - name: Install


### PR DESCRIPTION
Dependabot, Renovate, etc. can automate most of these changes.
* https://github.com/actions/cache/releases
* https://github.com/actions/checkout/releases
* https://github.com/actions/download-artifact/releases
* https://github.com/actions/setup-python/releases
* https://github.com/actions/upload-artifact/releases