### PR TITLE
Fix ffmpeg libraries search under `python -S`

### DIFF
--- a/ffpyplayer/__init__.py
+++ b/ffpyplayer/__init__.py
@@ -39,6 +39,8 @@ It is read only.
 '''
 
 for d in [sys.prefix, site.USER_BASE]:
+    if d is None:
+        continue
     for lib in ('ffmpeg', 'sdl'):
         p = join(d, 'share', 'ffpyplayer', lib, 'bin')
         if os.path.isdir(p):


### PR DESCRIPTION
As per site's docs (https://docs.python.org/3/library/site.html#site.USER_SITE), `site.USER_BASE` may be `None`.
```bash
$ python -S -c 'import site; print(site.USER_SITE)'
None
```
Blindly passing `None` to `os.path.join()` leads to a type error on startup. PyInstaller applications effectively run in `-S` mode so this change also fixes PyInstaller compatibility.