### PR TITLE
Update zlib download url for macOS dependencies

### DIFF
--- a/.ci/build_wheels_osx.sh
+++ b/.ci/build_wheels_osx.sh
@@ -40,7 +40,7 @@ make install
 
 
 cd "$SRC_PATH"
-curl -sLO "https://zlib.net/zlib-$ZLIB_VERSION.tar.gz"
+curl -sLO "https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz"
 tar xzf "zlib-$ZLIB_VERSION.tar.gz"
 cd "zlib-$ZLIB_VERSION"
 ./configure --prefix="$BUILD_PATH"


### PR DESCRIPTION
- ⚠️ CI is expected to fail as `ffpyplayer` is incompatible with Cython 3 and the version has been left unpinned. (See PR: )
- Changes a broken URL for `zlib` in macOS dependencies.