### PR TITLE
Force `Cython~=0.29.36`, as `ffpyplayer` is incompatible with `Cython>=3` (ATM)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -64,7 +64,7 @@ jobs:
       run: python setup.py sdist --formats=gztar
     - name: Install pip deps
       run: |
-        python -m pip install --upgrade pip virtualenv wheel setuptools cython pytest
+        python -m pip install --upgrade pip virtualenv wheel setuptools cython~=0.29.36 pytest
     - name: Make wheel
       run: |
         $env:SDL_ROOT=(get-item $env:SDL_ROOT).FullName

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -28,7 +28,7 @@ Requirements
 
 To compile ffpyplayer we need:
 
-    * Cython (``pip install --upgrade cython``).
+    * Cython (``pip install --upgrade cython~=0.29.36``).
     * A c compiler e.g. gcc or MSVC.
     * SDL2 or SDL1.2 (SDL1.2 is not recommended). See :ref:`compille` for how to get it.
     * SDL2_mixer If wanting to play multiple audio files simultaneously (``USE_SDL2_MIXER`` must be set). See :ref:`compille` for how to get it.
@@ -41,7 +41,7 @@ Compiling ffpyplayer
 * Download or compile FFMpeg and SDL2 as shown below and set the appropriate environment variables as needed.
 * Install Cython with e.g.::
 
-      pip install --upgrade cython
+      pip install --upgrade cython~=0.29.36
 
 * You can select the FFmpeg libraries to be used by defining values for CONFIG_XXX.
   For example, CONFIG_AVFILTER=0 will disable inclusion of the FFmpeg avfilter libraries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 requires = [
-    "setuptools", "wheel", "cython",
+    "setuptools", "wheel", "cython~=0.29.36",
 ]

--- a/setup.py
+++ b/setup.py
@@ -376,7 +376,7 @@ with open('README.rst') as fh:
 
 setup_requires = []
 if declare_cython:
-    setup_requires.append('cython')
+    setup_requires.append('cython~=0.29.36')
 
 setup(name='ffpyplayer',
       version=ffpyplayer.__version__,


### PR DESCRIPTION
- Adding support to `Cython==3` is an option, but I'm quite in a hurry in order to get Kivy ready for **Python 3.12**, so what I needed is a `ffpyplayer` version which can actually be built. 
- Needs #151  to have a ✅ on CI status