### PR TITLE
Install pip deps on Windows, before creating the sdist, as `setuptools` is needed.

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -59,12 +59,12 @@ jobs:
         echo "Dependency paths are:"
         ls $env:SDL_ROOT
         ls $env:FFMPEG_ROOT
-    - name: Make sdist
-      if: matrix.python == '3.12'
-      run: python setup.py sdist --formats=gztar
     - name: Install pip deps
       run: |
         python -m pip install --upgrade pip virtualenv wheel setuptools cython~=0.29.36 pytest
+    - name: Make sdist
+      if: matrix.python == '3.12'
+      run: python setup.py sdist --formats=gztar
     - name: Make wheel
       run: |
         $env:SDL_ROOT=(get-item $env:SDL_ROOT).FullName


### PR DESCRIPTION
- `setuptools` is needed in order to build the `sdist`, and `setuptools` is not installed anymore by default on **Python 3.12** GA.

This PR, moves the sdist build after dependencies are installed, so we can be sure a valid `setuptools` is there.