### PR TITLE
Migrate to Cython 3

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -61,7 +61,7 @@ jobs:
         ls $env:FFMPEG_ROOT
     - name: Install pip deps
       run: |
-        python -m pip install --upgrade pip virtualenv wheel setuptools cython~=0.29.36 pytest
+        python -m pip install --upgrade pip virtualenv wheel setuptools cython~=3.0.11 pytest
     - name: Make sdist
       if: matrix.python == '3.12'
       run: python setup.py sdist --formats=gztar

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -28,7 +28,7 @@ Requirements
 
 To compile ffpyplayer we need:
 
-    * Cython (``pip install --upgrade cython~=0.29.36``).
+    * Cython (``pip install --upgrade cython~=3.0.11``).
     * A c compiler e.g. gcc or MSVC.
     * SDL2 or SDL1.2 (SDL1.2 is not recommended). See :ref:`compille` for how to get it.
     * SDL2_mixer If wanting to play multiple audio files simultaneously (``USE_SDL2_MIXER`` must be set). See :ref:`compille` for how to get it.
@@ -41,7 +41,7 @@ Compiling ffpyplayer
 * Download or compile FFMpeg and SDL2 as shown below and set the appropriate environment variables as needed.
 * Install Cython with e.g.::
 
-      pip install --upgrade cython~=0.29.36
+      pip install --upgrade cython~=3.0.11
 
 * You can select the FFmpeg libraries to be used by defining values for CONFIG_XXX.
   For example, CONFIG_AVFILTER=0 will disable inclusion of the FFmpeg avfilter libraries.

--- a/ffpyplayer/player/core.pyx
+++ b/ffpyplayer/player/core.pyx
@@ -1616,7 +1616,7 @@ cdef class VideoState(object):
             if self.audio_dev == -1:
                 return -1
 
-            if not Mix_RegisterEffect(self.audio_dev, <void (*)(int, void *, int, void *) nogil>sdl_mixer_callback, NULL, self.self_id):
+            if not Mix_RegisterEffect(self.audio_dev, <void (*)(int, void *, int, void *) noexcept nogil>sdl_mixer_callback, NULL, self.self_id):
                 return -1
 
         ELSE:
@@ -1654,7 +1654,7 @@ cdef class VideoState(object):
         wanted_spec.format = AUDIO_S16SYS
         wanted_spec.silence = 0
         wanted_spec.samples = FFMAX(AUDIO_MIN_BUFFER_SIZE, 2 << av_log2(wanted_spec.freq // AUDIO_MAX_CALLBACKS_PER_SEC))
-        wanted_spec.callback = <void (*)(void *, uint8_t *, int) nogil>self.sdl_audio_callback
+        wanted_spec.callback = <void (*)(void *, uint8_t *, int) noexcept nogil>self.sdl_audio_callback
         wanted_spec.userdata = self.self_id
 
         error = self.open_audio_device(&wanted_spec, &spec)
@@ -1869,7 +1869,7 @@ cdef class VideoState(object):
         if codecpar.codec_type == AVMEDIA_TYPE_AUDIO:
             self.auddec.decoder_abort(self.sampq)
             IF USE_SDL2_MIXER:
-                Mix_UnregisterEffect(self.audio_dev, <void (*)(int, void *, int, void *) nogil>sdl_mixer_callback)
+                Mix_UnregisterEffect(self.audio_dev, <void (*)(int, void *, int, void *) noexcept nogil>sdl_mixer_callback)
                 Mix_HaltChannel(self.audio_dev)
                 Mix_FreeChunk(self.chunk)
                 self.chunk = NULL
@@ -1942,7 +1942,7 @@ cdef class VideoState(object):
                 av_log(NULL, AV_LOG_FATAL, b"Could not allocate context.\n");
             return self.failed(AVERROR(ENOMEM), ic, &pkt)
         #av_opt_set_int(ic, b"threads", 1, 0)
-        ic.interrupt_callback.callback = <int (*)(void *)>self.decode_interrupt_cb
+        ic.interrupt_callback.callback = <int (*)(void *) noexcept>self.decode_interrupt_cb
         ic.interrupt_callback.opaque = self.self_id
 
         if not av_dict_get(self.player.format_opts, b"scan_all_pmts", NULL, AV_DICT_MATCH_CASE):

--- a/ffpyplayer/tools.pyx
+++ b/ffpyplayer/tools.pyx
@@ -78,17 +78,6 @@ the log.
 '''
 _loglevel_inverse = {v:k for k, v in loglevels.iteritems()}
 
-codecs_enc = get_codecs(encode=True, video=True)
-'''A list of all the codecs available for encoding video. '''
-codecs_dec = get_codecs(decode=True, video=True, audio=True)
-'''A list of all the codecs available for decoding video and audio. '''
-pix_fmts = list_pixfmts()
-'''A list of all the pixel formats available to ffmpeg. '''
-formats_in = get_fmts(input=True)[0]
-'''A list of all the formats (e.g. file formats) available for reading. '''
-formats_out = get_fmts(output=True)[0]
-'''A list of all the formats (e.g. file formats) available for writing. '''
-
 cdef object _log_callback = None
 cdef MTMutex _log_mutex= MTMutex(SDL_MT)
 cdef int log_level = AV_LOG_WARNING
@@ -105,7 +94,7 @@ cdef void call_callback(char *line, int level) nogil:
     with gil:
         gil_call_callback(line, level)
 
-cdef void _log_callback_func(void* ptr, int level, const char* fmt, va_list vl) nogil:
+cdef void _log_callback_func(void* ptr, int level, const char* fmt, va_list vl) noexcept nogil:
     cdef char line[2048]
     if fmt == NULL or level > log_level:
         return
@@ -278,6 +267,11 @@ cpdef get_codecs(
         codec = av_codec_iterate(&iter_codec)
     return sorted(codecs)
 
+codecs_enc = get_codecs(encode=True, video=True)
+'''A list of all the codecs available for encoding video. '''
+codecs_dec = get_codecs(decode=True, video=True, audio=True)
+'''A list of all the codecs available for decoding video and audio. '''
+
 cdef list list_pixfmts():
     cdef list fmts = []
     cdef const AVPixFmtDescriptor *desc = NULL
@@ -287,6 +281,9 @@ cdef list list_pixfmts():
         fmts.append(tcode(desc.name))
         desc = av_pix_fmt_desc_next(desc)
     return sorted(fmts)
+
+pix_fmts = list_pixfmts()
+'''A list of all the pixel formats available to ffmpeg. '''
 
 cpdef get_fmts(int input=False, int output=False):
     '''Returns the formats available in FFmpeg.
@@ -350,6 +347,10 @@ cpdef get_fmts(int input=False, int output=False):
     fmts = sorted(fmts)
     return fmts, full_names, exts
 
+formats_in = get_fmts(input=True)[0]
+'''A list of all the formats (e.g. file formats) available for reading. '''
+formats_out = get_fmts(output=True)[0]
+'''A list of all the formats (e.g. file formats) available for writing. '''
 
 def get_format_codec(filename=None, fmt=None):
     '''Returns the best codec associated with the file format. The format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 requires = [
-    "setuptools", "wheel", "cython~=0.29.36",
+    "setuptools", "wheel", "cython~=3.0.11",
 ]

--- a/setup.py
+++ b/setup.py
@@ -376,7 +376,7 @@ with open('README.rst') as fh:
 
 setup_requires = []
 if declare_cython:
-    setup_requires.append('cython~=0.29.36')
+    setup_requires.append('cython~=3.0.11')
 
 setup(name='ffpyplayer',
       version=ffpyplayer.__version__,


### PR DESCRIPTION
Taken from #170 

- Requires #171 to build on macOS
- Updated to Cython 3, as is now stable, and is a requirement to build for Python 3.13
- Things have been moved around on `tools.pyx`, due to Cython 3 restrictions.