### PR TITLE
README.rst: Fix a bug in Python code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,5 +88,5 @@ Converting images:
     >>> img2.get_pixel_format()
     'yuv420p'
     >>> planes = img2.to_bytearray()
-    >>> map(len, planes)
+    >>> [len(plane) for plane in planes]
     [50000, 12500, 12500, 0]


### PR DESCRIPTION
[`map()`](https://docs.python.org/3/library/functions.html#map) returned a list in Python 2 but returns an iterator in Python 3.
* https://docs.python.org/3/whatsnew/3.0.html#views-and-iterators-instead-of-lists
> [map()](https://docs.python.org/3/library/functions.html#map) and [filter()](https://docs.python.org/3/library/functions.html#filter) return iterators. If you really need a list and the input sequences are all of equal length, a quick fix is to wrap [map()](https://docs.python.org/3/library/functions.html#map) in [list()](https://docs.python.org/3/library/stdtypes.html#list), e.g. list(map(...)), but a better fix is often to use a list comprehension (especially when the original code uses [lambda](https://docs.python.org/3/reference/expressions.html#lambda)), or rewriting the code so it doesn’t need a list at all.
```python
>>> planes = ('', 'a', 'ab', 'abc')
>>> map(len, planes)
<map object at 0x1031e74c0>
>>> [len(plane) for plane in planes]
[0, 1, 2, 3]
```