### PR TITLE
`python3.14 -m pip install ffpyplayer` fails

### DIFF
--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -57,7 +57,7 @@ make install;
 make distclean;
 
 cd ~/ffmpeg_sources;
-curl -kLO "https://cfhcable.dl.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
+curl -kLO "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar xzf "lame-$LAME_VERSION.tar.gz"
 cd "lame-$LAME_VERSION"
 ./configure --prefix="$BUILD_DIR" --enable-nasm --enable-shared;

--- a/.ci/build_wheels_osx.sh
+++ b/.ci/build_wheels_osx.sh
@@ -127,7 +127,7 @@ if [ "$ARCH" = "x86_64" ]; then
   arg=("--enable-nasm")
 fi
 cd "$SRC_PATH";
-curl -kLO "https://cfhcable.dl.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
+curl -kLO "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar xzf "lame-$LAME_VERSION.tar.gz"
 cd "lame-$LAME_VERSION"
 git apply "$base_dir/.ci/libmp3lame-symbols.patch"

--- a/.github/workflows/pip_install_on_py314.yml
+++ b/.github/workflows/pip_install_on_py314.yml
@@ -1,0 +1,29 @@
+name: pip_install_on_py314
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  pip_install_on_py314:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install libsdl2-dev
+    - if: runner.os == 'macOS'
+      run: brew install ffmpeg sdl2
+    - if: runner.os == 'Windows'
+      run: |
+        curl -LO https://github.com/libsdl-org/SDL/releases/download/release-2.32.10/SDL2-devel-2.32.10-VC.zip
+        unzip SDL2-devel-2.32.10-VC.zip -d $env:USERPROFILE\SDL2
+        echo "SDL2_INCLUDE_DIR=$env:USERPROFILE\SDL2\SDL2-2.32.10\include" | Out-File -FilePath $env:GITHUB_ENV -Append
+        echo "SDL2_LIB_DIR=$env:USERPROFILE\SDL2\SDL2-2.32.10\lib\x64" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
+      with:
+        python-version: 3.14
+    - run: pip install --upgrade pip
+    - run: pip install ffpyplayer

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -170,10 +170,10 @@ jobs:
     needs: linux_wheels
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Set up Python 3.x
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: 3.x
+          python-version: 3.13  # 3.14 fails!
       - uses: actions/download-artifact@v4.2.1
         with:
           pattern: py_wheel-*


### PR DESCRIPTION
https://www.python.org/downloads/release/python-3140/

% `python3.13 -m pip install ffpyplayer ` # is successful.
% `python3.14 -m pip install ffpyplayer ` # fails!
> includes/ffconfig.h:5:10: fatal error: SDL_version.h: No such file or directory

With [`uv`](https://docs.astral.sh/uv):
% `uvx --with=ffpyplayer python3.13 -c "import ffpyplayer" ` # is successful.
% `uvx --with=ffpyplayer python3.14 -c "import ffpyplayer" ` # fails!

Does ___SDL___ need an upgrade for Python 3.14?
* https://github.com/libsdl-org/SDL

This PR merely demonstrates that new wheels need to be published to PyPI to support Python 3.14.
I am happy to close this with unmerged commits after all of its tests pass.