### PR TITLE
macOS: brew install ffmpeg

### DIFF
--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -57,7 +57,7 @@ make install;
 make distclean;
 
 cd ~/ffmpeg_sources;
-curl -kLO "https://cfhcable.dl.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
+curl -kLO "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar xzf "lame-$LAME_VERSION.tar.gz"
 cd "lame-$LAME_VERSION"
 ./configure --prefix="$BUILD_DIR" --enable-nasm --enable-shared;

--- a/.ci/build_wheels_osx.sh
+++ b/.ci/build_wheels_osx.sh
@@ -127,7 +127,7 @@ if [ "$ARCH" = "x86_64" ]; then
   arg=("--enable-nasm")
 fi
 cd "$SRC_PATH";
-curl -kLO "https://cfhcable.dl.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
+curl -kLO "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar xzf "lame-$LAME_VERSION.tar.gz"
 cd "lame-$LAME_VERSION"
 git apply "$base_dir/.ci/libmp3lame-symbols.patch"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -170,10 +170,10 @@ jobs:
     needs: linux_wheels
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Set up Python 3.x
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: 3.x
+          python-version: 3.13  # 3.14 fails!
       - uses: actions/download-artifact@v4.2.1
         with:
           pattern: py_wheel-*
@@ -284,13 +284,14 @@ jobs:
         with:
           path: ~/${{ env.FFMPEG_BUILD_PATH }}_${{ matrix.arch }}
           key: ${{ runner.os }}-ffmpeg-${{ matrix.arch }}-${{ env.MACOSX_DEPLOYMENT_TARGET }}-${{ env.MACOSX_DEPLOYMENT_TARGET_ARM }}-${{ hashFiles('.ci/build_wheels_osx.sh') }}
-      - name: Build FFmpeg
-        if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
-        run: bash .ci/build_wheels_osx.sh "${{ matrix.arch }}"
+      #- name: Build FFmpeg
+      #  if: steps.cache-ffmpeg.outputs.cache-hit != 'true'
+      #  run: bash .ci/build_wheels_osx.sh "${{ matrix.arch }}"
+      - run: brew install ffmpeg  # https://formulae.brew.sh/formula/ffmpeg
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel~=2.23.3
+          python -m pip install cibuildwheel~=2.23.3 cython setuptools
       - name: Build wheels
         run: |
           export REPAIR_LIBRARY_PATH="$HOME/${{ env.FFMPEG_BUILD_PATH }}_${{ matrix.arch }}/lib"


### PR DESCRIPTION
https://github.com/matham/ffpyplayer/actions/workflows/pythonapp.yml is failing for thre months.
* https://formulae.brew.sh/formula/ffmpeg

> In file included from /Users/runner/work/ffpyplayer/ffpyplayer/ffpyplayer/clib/misc.c:2:
    /Users/runner/work/ffpyplayer/ffpyplayer/ffpyplayer/clib/misc.h:18:10: fatal error: 'libpostproc/postprocess.h' file not found
    #include "libpostproc/postprocess.h"
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    1 warning and 1 error generated.
    error: command '/usr/bin/gcc' failed with exit code 1
    error: subprocess-exited-with-error