### PR TITLE
Upgrade from deprecated macos-13 to macos-15-intel in CI

### DIFF
--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -57,7 +57,7 @@ make install;
 make distclean;
 
 cd ~/ffmpeg_sources;
-curl -kLO "https://cfhcable.dl.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
+curl -kLO "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar xzf "lame-$LAME_VERSION.tar.gz"
 cd "lame-$LAME_VERSION"
 ./configure --prefix="$BUILD_DIR" --enable-nasm --enable-shared;

--- a/.ci/build_wheels_osx.sh
+++ b/.ci/build_wheels_osx.sh
@@ -14,7 +14,7 @@ export PATH="$BUILD_PATH/bin:/usr/local/bin/:$PATH"
 export PKG_CONFIG_PATH="$BUILD_PATH/lib/pkgconfig:/usr/lib/pkgconfig/:$PKG_CONFIG_PATH"
 export CC="/usr/bin/clang"
 export CXX="/usr/bin/clang"
-export MACOSX_DEPLOYMENT_TARGET=10.13
+export MACOSX_DEPLOYMENT_TARGET=11.0
 
 if [ "$ARCH" = "x86_64" ]; then
   ARCH2=x86_64

--- a/.ci/build_wheels_osx.sh
+++ b/.ci/build_wheels_osx.sh
@@ -127,7 +127,7 @@ if [ "$ARCH" = "x86_64" ]; then
   arg=("--enable-nasm")
 fi
 cd "$SRC_PATH";
-curl -kLO "https://cfhcable.dl.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
+curl -kLO "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar xzf "lame-$LAME_VERSION.tar.gz"
 cd "lame-$LAME_VERSION"
 git apply "$base_dir/.ci/libmp3lame-symbols.patch"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -7,7 +7,7 @@ env:
   SDL_VERSION: "2.26.4"  # https://github.com/libsdl-org/SDL/releases
   SDL_MIXER_VERSION: "2.6.3"  # https://github.com/libsdl-org/SDL_mixer/releases
   USE_SDL2_MIXER: "1"
-  MACOSX_DEPLOYMENT_TARGET: "10.13"
+  MACOSX_DEPLOYMENT_TARGET: "11.0"
   MACOSX_DEPLOYMENT_TARGET_ARM: "11.0"
 
 jobs:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -258,7 +258,7 @@ jobs:
           twine upload dist/*
 
   osx_wheels_create:
-    runs-on: macos-15-intel
+    runs-on: macos-13  # macos-15-intel fails!
     env:
       USE_SDL2_MIXER: 0
       FFMPEG_BUILD_PATH: "ffmpeg_build"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -170,10 +170,10 @@ jobs:
     needs: linux_wheels
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Set up Python 3.x
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: 3.x
+          python-version: 3.13  # 3.14 fails!
       - uses: actions/download-artifact@v4.2.1
         with:
           pattern: py_wheel-*
@@ -258,7 +258,7 @@ jobs:
           twine upload dist/*
 
   osx_wheels_create:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     env:
       USE_SDL2_MIXER: 0
       FFMPEG_BUILD_PATH: "ffmpeg_build"
@@ -269,6 +269,7 @@ jobs:
         DYLD_FALLBACK_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-listdeps {wheel} &&
         DYLD_FALLBACK_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
     strategy:
+      fail-fast: false
       matrix:
         arch: [ "x86_64", "arm64" ]
     steps:
@@ -304,7 +305,7 @@ jobs:
           path: dist
 
   osx_wheels_fuse_test_upload:
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs: osx_wheels_create
     steps:
       - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Replace GitHub Actions runner image `macos-13` with `macos-15-intel` as recommended in:
* https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down
> The macOS 13 runner image will be retired by ___December 4th, 2025___.

The currently available GitHub Actions macOS runners are:
| macOS Version | runner.arch |
|---------------|-------------|
| macos-13 | X64 |
| macos-14 | ARM64 |
| macos-15 | ARM64 |
| macos-15-intel | X64 |
| macos-26 | ARM64 |
| macos-latest | ARM64 |