### PR TITLE
Move `nogil` to end of function signatures

### DIFF
--- a/.ci/build-wheels.sh
+++ b/.ci/build-wheels.sh
@@ -57,7 +57,7 @@ make install;
 make distclean;
 
 cd ~/ffmpeg_sources;
-curl -kLO "https://cfhcable.dl.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
+curl -kLO "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar xzf "lame-$LAME_VERSION.tar.gz"
 cd "lame-$LAME_VERSION"
 ./configure --prefix="$BUILD_DIR" --enable-nasm --enable-shared;

--- a/.ci/build_wheels_osx.sh
+++ b/.ci/build_wheels_osx.sh
@@ -127,7 +127,7 @@ if [ "$ARCH" = "x86_64" ]; then
   arg=("--enable-nasm")
 fi
 cd "$SRC_PATH";
-curl -kLO "https://cfhcable.dl.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
+curl -kLO "https://downloads.sourceforge.net/project/lame/lame/$LAME_VERSION/lame-$LAME_VERSION.tar.gz"
 tar xzf "lame-$LAME_VERSION.tar.gz"
 cd "lame-$LAME_VERSION"
 git apply "$base_dir/.ci/libmp3lame-symbols.patch"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -170,10 +170,10 @@ jobs:
     needs: linux_wheels
     steps:
       - uses: actions/checkout@v4.2.2
-      - name: Set up Python 3.x
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: 3.x
+          python-version: 3.13  # 3.14 fails!
       - uses: actions/download-artifact@v4.2.1
         with:
           pattern: py_wheel-*

--- a/ffpyplayer/pic.pxd
+++ b/ffpyplayer/pic.pxd
@@ -18,7 +18,7 @@ cdef class Image(object):
     cdef list byte_planes
     cdef AVPixelFormat pix_fmt
 
-    cdef int cython_init(self, AVFrame *frame) nogil except 1
+    cdef int cython_init(self, AVFrame *frame) except 1 nogil
     cpdef is_ref(Image self)
     cpdef is_key_frame(Image self)
     cpdef get_linesizes(Image self, keep_align=*)

--- a/ffpyplayer/pic.pyx
+++ b/ffpyplayer/pic.pyx
@@ -289,7 +289,7 @@ cdef class SWScale(object):
         return dst
 
 
-cdef int raise_exec(object ecls) nogil except 1:
+cdef int raise_exec(object ecls) except 1 nogil:
     with gil:
         raise ecls()
 
@@ -443,7 +443,7 @@ cdef class Image(object):
     def __dealloc__(self):
         av_frame_free(&self.frame)
 
-    cdef int cython_init(self, AVFrame *frame) nogil except 1:
+    cdef int cython_init(self, AVFrame *frame) except 1 nogil:
         '''Can be called only once after object creation and it creates a internal
         reference to ``frame``.
         '''

--- a/ffpyplayer/player/core.pxd
+++ b/ffpyplayer/player/core.pxd
@@ -126,52 +126,52 @@ cdef class VideoState(object):
 
 
     cdef int cInit(self, MTGenerator mt_gen, VideoSettings *player, int paused,
-                   AVPixelFormat out_fmt) nogil except 1
-    cdef int cquit(VideoState self) nogil except 1
-    cdef int request_thread_s(self, char *name, char *msg) nogil except 1
-    cdef int request_thread(self, char *name, object msg) nogil except 1
+                   AVPixelFormat out_fmt) except 1 nogil
+    cdef int cquit(VideoState self) except 1 nogil
+    cdef int request_thread_s(self, char *name, char *msg) except 1 nogil
+    cdef int request_thread(self, char *name, object msg) except 1 nogil
     cdef int request_thread_py(self, object name, object msg) except 1
     cdef object get_out_pix_fmt(self)
     cdef void set_out_pix_fmt(self, AVPixelFormat out_fmt)
     cdef int get_master_sync_type(VideoState self) nogil
-    cdef double get_master_clock(VideoState self) nogil except? 0.0
-    cdef int check_external_clock_speed(VideoState self) nogil except 1
-    cdef int stream_seek(VideoState self, int64_t pos, int64_t rel, int seek_by_bytes, int flush) nogil except 1
-    cdef int seek_chapter(VideoState self, int incr, int flush) nogil except 1
-    cdef int toggle_pause(VideoState self) nogil except 1
-    cdef double compute_target_delay(VideoState self, double delay) nogil except? 0.0
-    cdef double vp_duration(VideoState self, Frame *vp, Frame *nextvp) nogil except? 0.0
+    cdef double get_master_clock(VideoState self) except? 0.0 nogil
+    cdef int check_external_clock_speed(VideoState self) except 1 nogil
+    cdef int stream_seek(VideoState self, int64_t pos, int64_t rel, int seek_by_bytes, int flush) except 1 nogil
+    cdef int seek_chapter(VideoState self, int incr, int flush) except 1 nogil
+    cdef int toggle_pause(VideoState self) except 1 nogil
+    cdef double compute_target_delay(VideoState self, double delay) except? 0.0 nogil
+    cdef double vp_duration(VideoState self, Frame *vp, Frame *nextvp) except? 0.0 nogil
     cdef void update_video_pts(VideoState self, double pts, int64_t pos, int serial) nogil
     cdef int video_refresh(VideoState self, Image next_image, double *pts, double *remaining_time,
-                           int force_refresh) nogil except -1
-    cdef int get_video_frame(VideoState self, AVFrame *frame) nogil except 2
+                           int force_refresh) except -1 nogil
+    cdef int get_video_frame(VideoState self, AVFrame *frame) except 2 nogil
     IF CONFIG_AVFILTER:
         cdef int configure_filtergraph(VideoState self, AVFilterGraph *graph, const char *filtergraph,
-                                       AVFilterContext *source_ctx, AVFilterContext *sink_ctx) nogil except? 1
+                                       AVFilterContext *source_ctx, AVFilterContext *sink_ctx) except? 1 nogil
         cdef int configure_video_filters(VideoState self, AVFilterGraph *graph,
                                          const char *vfilters, AVFrame *frame,
-                                         AVPixelFormat pix_fmt) nogil except? 1
+                                         AVPixelFormat pix_fmt) except? 1 nogil
         cdef int configure_audio_filters(VideoState self, const char *afilters,
-                                         int force_output_format) nogil except? 1
-    cdef int audio_thread(self) nogil except? 1
-    cdef int video_thread(VideoState self) nogil except? 1
-    cdef int subtitle_thread(VideoState self) nogil except 1
-    cdef int subtitle_display(self, AVSubtitle *sub) nogil except 1
-    cdef int update_sample_display(VideoState self, int16_t *samples, int samples_size) nogil except 1
-    cdef int synchronize_audio(VideoState self, int nb_samples) nogil except -1
-    cdef int audio_decode_frame(VideoState self) nogil except? 1
-    cdef int sdl_audio_callback(VideoState self, uint8_t *stream, int len) nogil except 1
-    cdef inline int open_audio_device(VideoState self, SDL_AudioSpec *wanted_spec, SDL_AudioSpec *spec) nogil except 1
+                                         int force_output_format) except? 1 nogil
+    cdef int audio_thread(self) except? 1 nogil
+    cdef int video_thread(VideoState self) except? 1 nogil
+    cdef int subtitle_thread(VideoState self) except 1 nogil
+    cdef int subtitle_display(self, AVSubtitle *sub) except 1 nogil
+    cdef int update_sample_display(VideoState self, int16_t *samples, int samples_size) except 1 nogil
+    cdef int synchronize_audio(VideoState self, int nb_samples) except -1 nogil
+    cdef int audio_decode_frame(VideoState self) except? 1 nogil
+    cdef int sdl_audio_callback(VideoState self, uint8_t *stream, int len) except 1 nogil
+    cdef inline int open_audio_device(VideoState self, SDL_AudioSpec *wanted_spec, SDL_AudioSpec *spec) except 1 nogil
     cdef int audio_open(VideoState self, int64_t wanted_channel_layout, int wanted_nb_channels,
-                        int wanted_sample_rate, AudioParams *audio_hw_params) nogil except? 1
-    cdef int stream_component_open(VideoState self, int stream_index) nogil except 1
-    cdef int stream_component_close(VideoState self, int stream_index) nogil except 1
-    cdef int read_thread(VideoState self) nogil except 1
+                        int wanted_sample_rate, AudioParams *audio_hw_params) except? 1 nogil
+    cdef int stream_component_open(VideoState self, int stream_index) except 1 nogil
+    cdef int stream_component_close(VideoState self, int stream_index) except 1 nogil
+    cdef int read_thread(VideoState self) except 1 nogil
     cdef int stream_has_enough_packets(self, AVStream *st, int stream_id, FFPacketQueue queue) nogil
-    cdef inline int failed(VideoState self, int ret, AVFormatContext *ic, AVPacket **pkt) nogil except 1
-    cdef int stream_select_program(VideoState self, int requested_program) nogil except 1
-    cdef int stream_select_channel(VideoState self, int codec_type, unsigned int requested_stream) nogil except 1
-    cdef int stream_cycle_channel(VideoState self, int codec_type) nogil except 1
+    cdef inline int failed(VideoState self, int ret, AVFormatContext *ic, AVPacket **pkt) except 1 nogil
+    cdef int stream_select_program(VideoState self, int requested_program) except 1 nogil
+    cdef int stream_select_channel(VideoState self, int codec_type, unsigned int requested_stream) except 1 nogil
+    cdef int stream_cycle_channel(VideoState self, int codec_type) except 1 nogil
     cdef int decode_interrupt_cb(VideoState self) nogil
 
 

--- a/ffpyplayer/player/decoder.pxd
+++ b/ffpyplayer/player/decoder.pxd
@@ -26,10 +26,10 @@ cdef class Decoder(object):
         MTGenerator mt_gen
 
     cdef int decoder_init(self, MTGenerator mt_gen, AVCodecContext *avctx, FFPacketQueue queue,
-                           MTCond empty_queue_cond) nogil except 1
+                           MTCond empty_queue_cond) except 1 nogil
     cdef void decoder_destroy(self) nogil
     cdef void set_seek_pos(self, double seek_req_pos) nogil
     cdef int is_seeking(self) nogil
-    cdef int decoder_abort(self, FrameQueue fq) nogil except 1
-    cdef int decoder_start(self, int_void_func func, const char *thread_name, void *arg) nogil except 1
-    cdef int decoder_decode_frame(self, AVFrame *frame, AVSubtitle *sub, int decoder_reorder_pts) nogil except? 2
+    cdef int decoder_abort(self, FrameQueue fq) except 1 nogil
+    cdef int decoder_start(self, int_void_func func, const char *thread_name, void *arg) except 1 nogil
+    cdef int decoder_decode_frame(self, AVFrame *frame, AVSubtitle *sub, int decoder_reorder_pts) except? 2 nogil

--- a/ffpyplayer/player/decoder.pyx
+++ b/ffpyplayer/player/decoder.pyx
@@ -20,7 +20,7 @@ cdef class Decoder(object):
 
     cdef int decoder_init(
             self, MTGenerator mt_gen, AVCodecContext *avctx, FFPacketQueue queue,
-            MTCond empty_queue_cond) nogil except 1:
+            MTCond empty_queue_cond) except 1 nogil:
         self.pkt = av_packet_alloc()
 
         with gil:
@@ -52,7 +52,7 @@ cdef class Decoder(object):
     cdef int is_seeking(self) nogil:
         return self.seeking and self.seek_req_pos != -1
 
-    cdef int decoder_abort(self, FrameQueue fq) nogil except 1:
+    cdef int decoder_abort(self, FrameQueue fq) except 1 nogil:
         self.queue.packet_queue_abort()
         fq.frame_queue_signal()
         self.decoder_tid.wait_thread(NULL)
@@ -61,14 +61,14 @@ cdef class Decoder(object):
         self.queue.packet_queue_flush()
         return 0
 
-    cdef int decoder_start(self, int_void_func func, const char *thread_name, void *arg) nogil except 1:
+    cdef int decoder_start(self, int_void_func func, const char *thread_name, void *arg) except 1 nogil:
         self.queue.packet_queue_start()
         with gil:
             self.decoder_tid = MTThread(self.mt_gen.mt_src)
             self.decoder_tid.create_thread(func, thread_name, arg)
         return 0
 
-    cdef int decoder_decode_frame(self, AVFrame *frame, AVSubtitle *sub, int decoder_reorder_pts) nogil except? 2:
+    cdef int decoder_decode_frame(self, AVFrame *frame, AVSubtitle *sub, int decoder_reorder_pts) except? 2 nogil:
         cdef int ret = AVERROR(EAGAIN)
         cdef int got_frame
         cdef AVRational tb

--- a/ffpyplayer/player/frame_queue.pxd
+++ b/ffpyplayer/player/frame_queue.pxd
@@ -38,25 +38,25 @@ cdef class FrameQueue(object):
         int requested_alloc
 
     cdef void frame_queue_unref_item(self, Frame *vp) nogil
-    cdef int frame_queue_signal(self) nogil except 1
+    cdef int frame_queue_signal(self) except 1 nogil
     cdef int is_empty(self) nogil
     cdef Frame *frame_queue_peek(self) nogil
     cdef Frame *frame_queue_peek_next(self) nogil
     cdef Frame *frame_queue_peek_last(self) nogil
     cdef Frame *frame_queue_peek_writable(self) nogil
     cdef Frame *frame_queue_peek_readable(self) nogil
-    cdef int frame_queue_push(self) nogil except 1
-    cdef int frame_queue_next(self) nogil except 1
+    cdef int frame_queue_push(self) except 1 nogil
+    cdef int frame_queue_next(self) except 1 nogil
     cdef int frame_queue_prev(self) nogil
     cdef int frame_queue_nb_remaining(self) nogil
     cdef int64_t frame_queue_last_pos(self) nogil
     cdef int copy_picture(self, Frame *vp, AVFrame *src_frame,
-                          VideoSettings *player) nogil except 1
+                          VideoSettings *player) except 1 nogil
     cdef int peep_alloc(self) nogil
     cdef int queue_picture(
         self, AVFrame *src_frame, double pts, double duration, int64_t pos,
         int serial, AVPixelFormat out_fmt, int *abort_request,
-        VideoSettings *player) nogil except 1
-    cdef int alloc_picture(self) nogil except 1
+        VideoSettings *player) except 1 nogil
+    cdef int alloc_picture(self) except 1 nogil
     cdef int copy_picture(self, Frame *vp, AVFrame *src_frame,
-                           VideoSettings *player) nogil except 1
+                           VideoSettings *player) except 1 nogil

--- a/ffpyplayer/player/frame_queue.pyx
+++ b/ffpyplayer/player/frame_queue.pyx
@@ -7,7 +7,7 @@ include "../includes/inline_funcs.pxi"
 cdef extern from "string.h" nogil:
     void * memset(void *, int, size_t)
 
-cdef void raise_py_exception(msg) nogil except *:
+cdef void raise_py_exception(msg) except * nogil:
     with gil:
         raise Exception(tcode(msg))
 
@@ -49,7 +49,7 @@ cdef class FrameQueue(object):
         av_frame_unref(vp.frame)
         avsubtitle_free(&vp.sub)
 
-    cdef int frame_queue_signal(self) nogil except 1:
+    cdef int frame_queue_signal(self) except 1 nogil:
         self.cond.lock()
         self.cond.cond_signal()
         self.cond.unlock()
@@ -91,7 +91,7 @@ cdef class FrameQueue(object):
 
         return &self.queue[(self.rindex + self.rindex_shown) % self.max_size]
 
-    cdef int frame_queue_push(self) nogil except 1:
+    cdef int frame_queue_push(self) except 1 nogil:
         self.windex += 1
         if self.windex == self.max_size:
             self.windex = 0
@@ -102,7 +102,7 @@ cdef class FrameQueue(object):
         self.cond.unlock()
         return 0
 
-    cdef int frame_queue_next(self) nogil except 1:
+    cdef int frame_queue_next(self) except 1 nogil:
         if self.keep_last and not self.rindex_shown:
             self.rindex_shown = 1
             return 0
@@ -137,7 +137,7 @@ cdef class FrameQueue(object):
             return -1
 
     cdef int copy_picture(self, Frame *vp, AVFrame *src_frame,
-                           VideoSettings *player) nogil except 1:
+                           VideoSettings *player) except 1 nogil:
         cdef const AVDictionaryEntry *e
         cdef const AVClass *cls
         cdef const AVOption *o
@@ -167,7 +167,7 @@ cdef class FrameQueue(object):
             av_frame_unref(src_frame)
         return 0
 
-    cdef int alloc_picture(self) nogil except 1:
+    cdef int alloc_picture(self) except 1 nogil:
         ''' allocate a picture (needs to do that in main thread to avoid
         potential locking problems '''
         cdef Frame *vp
@@ -206,7 +206,7 @@ cdef class FrameQueue(object):
     cdef int queue_picture(
             self, AVFrame *src_frame, double pts, double duration, int64_t pos,
             int serial, AVPixelFormat out_fmt, int *abort_request,
-            VideoSettings *player) nogil except 1:
+            VideoSettings *player) except 1 nogil:
         cdef Frame *vp
 
         IF 0:# and defined(DEBUG_SYNC):

--- a/ffpyplayer/player/queue.pxd
+++ b/ffpyplayer/player/queue.pxd
@@ -19,11 +19,11 @@ cdef class FFPacketQueue(object):
         int serial
         MTCond cond
 
-    cdef int packet_queue_put_private(FFPacketQueue self, AVPacket *pkt) nogil except 1
-    cdef int packet_queue_put_nullpacket(FFPacketQueue self, AVPacket *pkt, int stream_index) nogil except 1
-    cdef int packet_queue_put(FFPacketQueue self, AVPacket *pkt) nogil except 1
-    cdef int packet_queue_flush(FFPacketQueue self) nogil except 1
-    cdef int packet_queue_abort(FFPacketQueue self) nogil except 1
-    cdef int packet_queue_start(FFPacketQueue self) nogil except 1
+    cdef int packet_queue_put_private(FFPacketQueue self, AVPacket *pkt) except 1 nogil
+    cdef int packet_queue_put_nullpacket(FFPacketQueue self, AVPacket *pkt, int stream_index) except 1 nogil
+    cdef int packet_queue_put(FFPacketQueue self, AVPacket *pkt) except 1 nogil
+    cdef int packet_queue_flush(FFPacketQueue self) except 1 nogil
+    cdef int packet_queue_abort(FFPacketQueue self) except 1 nogil
+    cdef int packet_queue_start(FFPacketQueue self) except 1 nogil
     # return < 0 if aborted, 0 if no packet and > 0 if packet.
-    cdef int packet_queue_get(FFPacketQueue self, AVPacket *pkt, int block, int *serial) nogil except 0
+    cdef int packet_queue_get(FFPacketQueue self, AVPacket *pkt, int block, int *serial) except 0 nogil

--- a/ffpyplayer/player/queue.pyx
+++ b/ffpyplayer/player/queue.pyx
@@ -28,7 +28,7 @@ cdef class FFPacketQueue(object):
             self.packet_queue_flush()
             av_fifo_freep(&self.pkt_list)
 
-    cdef int packet_queue_put_private(FFPacketQueue self, AVPacket *pkt) nogil except 1:
+    cdef int packet_queue_put_private(FFPacketQueue self, AVPacket *pkt) except 1 nogil:
         cdef MyAVPacketList pkt1
         cdef int ret
 
@@ -53,7 +53,7 @@ cdef class FFPacketQueue(object):
         self.cond.cond_signal()
         return 0
 
-    cdef int packet_queue_put(FFPacketQueue self, AVPacket *pkt) nogil except 1:
+    cdef int packet_queue_put(FFPacketQueue self, AVPacket *pkt) except 1 nogil:
         cdef AVPacket *pkt1 = av_packet_alloc()
         cdef int ret = -1
 
@@ -71,11 +71,11 @@ cdef class FFPacketQueue(object):
 
         return ret
 
-    cdef int packet_queue_put_nullpacket(FFPacketQueue self, AVPacket *pkt, int stream_index) nogil except 1:
+    cdef int packet_queue_put_nullpacket(FFPacketQueue self, AVPacket *pkt, int stream_index) except 1 nogil:
         pkt.stream_index = stream_index
         return self.packet_queue_put(pkt)
 
-    cdef int packet_queue_flush(FFPacketQueue self) nogil except 1:
+    cdef int packet_queue_flush(FFPacketQueue self) except 1 nogil:
         cdef MyAVPacketList pkt1
         cdef int ret = 0
 
@@ -93,14 +93,14 @@ cdef class FFPacketQueue(object):
         self.cond.unlock()
         return ret
 
-    cdef int packet_queue_abort(FFPacketQueue self) nogil except 1:
+    cdef int packet_queue_abort(FFPacketQueue self) except 1 nogil:
         self.cond.lock()
         self.abort_request = 1
         self.cond.cond_signal()
         self.cond.unlock()
         return 0
 
-    cdef int packet_queue_start(FFPacketQueue self) nogil except 1:
+    cdef int packet_queue_start(FFPacketQueue self) except 1 nogil:
         self.cond.lock()
         self.abort_request = 0
         self.serial += 1
@@ -108,7 +108,7 @@ cdef class FFPacketQueue(object):
         return 0
 
     # return < 0 if aborted, 0 if no packet and > 0 if packet.
-    cdef int packet_queue_get(FFPacketQueue self, AVPacket *pkt, int block, int *serial) nogil except 0:
+    cdef int packet_queue_get(FFPacketQueue self, AVPacket *pkt, int block, int *serial) except 0 nogil:
         cdef MyAVPacketList pkt1
         cdef int ret = 0
 

--- a/ffpyplayer/threading.pxd
+++ b/ffpyplayer/threading.pxd
@@ -10,37 +10,37 @@ cdef class MTMutex(object):
     cdef MT_lib lib
     cdef void* mutex
 
-    cdef int lock(MTMutex self) nogil except 2
-    cdef int _lock_py(MTMutex self) nogil except 2
-    cdef int unlock(MTMutex self) nogil except 2
-    cdef int _unlock_py(MTMutex self) nogil except 2
+    cdef int lock(MTMutex self) except 2 nogil
+    cdef int _lock_py(MTMutex self) except 2 nogil
+    cdef int unlock(MTMutex self) except 2 nogil
+    cdef int _unlock_py(MTMutex self) except 2 nogil
 
 cdef class MTCond(object):
     cdef MT_lib lib
     cdef MTMutex mutex
     cdef void *cond
 
-    cdef int lock(MTCond self) nogil except 2
-    cdef int unlock(MTCond self) nogil except 2
-    cdef int cond_signal(MTCond self) nogil except 2
-    cdef int _cond_signal_py(MTCond self) nogil except 2
-    cdef int cond_wait(MTCond self) nogil except 2
-    cdef int _cond_wait_py(MTCond self) nogil except 2
-    cdef int cond_wait_timeout(MTCond self, uint32_t val) nogil except 2
-    cdef int _cond_wait_timeout_py(MTCond self, uint32_t val) nogil except 2
+    cdef int lock(MTCond self) except 2 nogil
+    cdef int unlock(MTCond self) except 2 nogil
+    cdef int cond_signal(MTCond self) except 2 nogil
+    cdef int _cond_signal_py(MTCond self) except 2 nogil
+    cdef int cond_wait(MTCond self) except 2 nogil
+    cdef int _cond_wait_py(MTCond self) except 2 nogil
+    cdef int cond_wait_timeout(MTCond self, uint32_t val) except 2 nogil
+    cdef int _cond_wait_timeout_py(MTCond self, uint32_t val) except 2 nogil
 
 cdef class MTThread(object):
     cdef MT_lib lib
     cdef void* thread
 
-    cdef int create_thread(MTThread self, int_void_func func, const char *thread_name, void *arg) nogil except 2
-    cdef int wait_thread(MTThread self, int *status) nogil except 2
+    cdef int create_thread(MTThread self, int_void_func func, const char *thread_name, void *arg) except 2 nogil
+    cdef int wait_thread(MTThread self, int *status) except 2 nogil
 
 
 cdef class MTGenerator(object):
     cdef MT_lib mt_src
 
-    cdef int delay(MTGenerator self, int delay) nogil except 2
+    cdef int delay(MTGenerator self, int delay) except 2 nogil
     cdef lockmgr_func get_lockmgr(MTGenerator self) nogil
 
 cdef lockmgr_func get_lib_lockmgr(MT_lib lib) nogil

--- a/ffpyplayer/threading.pyx
+++ b/ffpyplayer/threading.pyx
@@ -51,23 +51,23 @@ cdef class MTMutex(object):
         elif self.lib == Py_MT:
             Py_DECREF(<PyObject *>self.mutex)
 
-    cdef int lock(MTMutex self) nogil except 2:
+    cdef int lock(MTMutex self) except 2 nogil:
         if self.lib == SDL_MT:
             return SDL_mutexP(<SDL_mutex *>self.mutex)
         elif self.lib == Py_MT:
             return self._lock_py()
 
-    cdef int _lock_py(MTMutex self) nogil except 2:
+    cdef int _lock_py(MTMutex self) except 2 nogil:
         with gil:
             return not (<object>self.mutex).acquire()
 
-    cdef int unlock(MTMutex self) nogil except 2:
+    cdef int unlock(MTMutex self) except 2 nogil:
         if self.lib == SDL_MT:
             return SDL_mutexV(<SDL_mutex *>self.mutex)
         elif self.lib == Py_MT:
             return self._unlock_py()
 
-    cdef int _unlock_py(MTMutex self) nogil except 2:
+    cdef int _unlock_py(MTMutex self) except 2 nogil:
         with gil:
             (<object>self.mutex).release()
         return 0
@@ -95,41 +95,41 @@ cdef class MTCond(object):
         elif self.lib == Py_MT:
             Py_DECREF(<PyObject *>self.cond)
 
-    cdef int lock(MTCond self) nogil except 2:
+    cdef int lock(MTCond self) except 2 nogil:
         self.mutex.lock()
 
-    cdef int unlock(MTCond self) nogil except 2:
+    cdef int unlock(MTCond self) except 2 nogil:
         self.mutex.unlock()
 
-    cdef int cond_signal(MTCond self) nogil except 2:
+    cdef int cond_signal(MTCond self) except 2 nogil:
         if self.lib == SDL_MT:
             return SDL_CondSignal(<SDL_cond *>self.cond)
         elif self.lib == Py_MT:
             return self._cond_signal_py()
 
-    cdef int _cond_signal_py(MTCond self) nogil except 2:
+    cdef int _cond_signal_py(MTCond self) except 2 nogil:
         with gil:
             (<object>self.cond).notify()
         return 0
 
-    cdef int cond_wait(MTCond self) nogil except 2:
+    cdef int cond_wait(MTCond self) except 2 nogil:
         if self.lib == SDL_MT:
             return SDL_CondWait(<SDL_cond *>self.cond, <SDL_mutex *>self.mutex.mutex)
         elif self.lib == Py_MT:
             return self._cond_wait_py()
 
-    cdef int _cond_wait_py(MTCond self) nogil except 2:
+    cdef int _cond_wait_py(MTCond self) except 2 nogil:
         with gil:
             (<object>self.cond).wait()
         return 0
 
-    cdef int cond_wait_timeout(MTCond self, uint32_t val) nogil except 2:
+    cdef int cond_wait_timeout(MTCond self, uint32_t val) except 2 nogil:
         if self.lib == SDL_MT:
             return SDL_CondWaitTimeout(<SDL_cond *>self.cond, <SDL_mutex *>self.mutex.mutex, val)
         elif self.lib == Py_MT:
             return self._cond_wait_timeout_py(val)
 
-    cdef int _cond_wait_timeout_py(MTCond self, uint32_t val) nogil except 2:
+    cdef int _cond_wait_timeout_py(MTCond self, uint32_t val) except 2 nogil:
         with gil:
             (<object>self.cond).wait(val / 1000.)
         return 0
@@ -147,7 +147,7 @@ cdef class MTThread(object):
         if self.lib == Py_MT and self.thread != NULL:
             Py_DECREF(<PyObject *>self.thread)
 
-    cdef int create_thread(MTThread self, int_void_func func, const char *thread_name, void *arg) nogil except 2:
+    cdef int create_thread(MTThread self, int_void_func func, const char *thread_name, void *arg) except 2 nogil:
         if self.lib == SDL_MT:
             with gil:
                 self.thread = SDL_CreateThread(func, thread_name, arg)
@@ -163,7 +163,7 @@ cdef class MTThread(object):
                 thread.start()
         return 0
 
-    cdef int wait_thread(MTThread self, int *status) nogil except 2:
+    cdef int wait_thread(MTThread self, int *status) except 2 nogil:
         if self.lib == SDL_MT:
             if self.thread != NULL:
                 SDL_WaitThread(<SDL_Thread *>self.thread, status)
@@ -246,7 +246,7 @@ cdef class MTGenerator(object):
     def __cinit__(MTGenerator self, MT_lib mt_src, **kwargs):
         self.mt_src = mt_src
 
-    cdef int delay(MTGenerator self, int delay) nogil except 2:
+    cdef int delay(MTGenerator self, int delay) except 2 nogil:
         if self.mt_src == SDL_MT:
             SDL_Delay(delay)
         elif self.mt_src == Py_MT:


### PR DESCRIPTION
Fix build warnings like:
> warning: ffpyplayer\pic.pxd:21:61: The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython.

% ` git grep ' nogil '`

https://github.com/cython/cython/blob/e2ef20c527c7d0b1b01d2cbb486c0db92d54d323/Cython/Compiler/Parsing.py#L3148-L3151

Includes the fixes from:
* #191